### PR TITLE
商品詳細表示機能の実装１

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -9,6 +9,10 @@ class ItemsController < ApplicationController
     @item = Item.new
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+  
   def create
     @item = Item.new(item_params)
     @item.user_id = current_user.id

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,7 +6,7 @@ class Item < ApplicationRecord
   belongs_to_active_hash :delivery_day
   belongs_to_active_hash :prefecture
   belongs_to_active_hash :category
-  # has_one :user_transact
+   has_one :user_transact
   has_one_attached :image
 
   with_options presence: true do

--- a/app/models/user_transact.rb
+++ b/app/models/user_transact.rb
@@ -1,0 +1,3 @@
+class UserTransact < ApplicationRecord
+  has_one :user_transact
+end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,7 +129,7 @@
 
       <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item) do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img"%>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,13 +8,12 @@
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
 <% if @item.user_transact.present? %>
   <div class="sold-out">
     <span>Sold Out!!</span>
   </div>
 <% end %>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+
     </div>
     <div class="item-price-box">
       <span class="item-price">
@@ -25,12 +24,11 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 <% if user_signed_in? %>
   <% if current_user.id == @item.user.id %>
-    <%= link_to "商品の編集",  edit_item_path(@item), method: :get, class: "item-red-btn" %>
+    <%#= link_to "商品の編集",  edit_item_path(@item), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除",  item_path(@item), data: {turbo_method: :delete}, class:"item-destroy" %>
+    <%#= link_to "削除",  item_path(@item), data: {turbo_method: :delete}, class:"item-destroy" %>
   <% else %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
@@ -38,7 +36,6 @@
   <% end %>
 <% end %>
 
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
       <span><%= @item.description %></span>
@@ -106,9 +103,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href="#" class="another-item"><%=  @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,67 +4,70 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
-        <span>Sold Out!!</span>
-      </div>
+<% if @item.user_transact.present? %>
+  <div class="sold-out">
+    <span>Sold Out!!</span>
+  </div>
+<% end %>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+          <%= "¥ #{@item.price}" %> 
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.delivery_charge.name %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+<% if user_signed_in? %>
+  <% if current_user.id == @item.user.id %>
+    <%= link_to "商品の編集",  edit_item_path(@item), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
-
-
+    <%= link_to "削除",  item_path(@item), data: {turbo_method: :delete}, class:"item-destroy" %>
+  <% else %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
-
+  <% end %>
+<% end %>
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.item_condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.delivery_charge.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.delivery_day.name %></td>
         </tr>
       </tbody>
     </table>

--- a/db/migrate/20240505144557_create_user_transacts.rb
+++ b/db/migrate/20240505144557_create_user_transacts.rb
@@ -1,0 +1,8 @@
+class CreateUserTransacts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :user_transacts do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240505145258_add_item_id_to_user_transacts.rb
+++ b/db/migrate/20240505145258_add_item_id_to_user_transacts.rb
@@ -1,0 +1,5 @@
+class AddItemIdToUserTransacts < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :user_transacts, :item, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_25_121212) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_05_145258) do
   create_table "active_storage_attachments", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -54,6 +54,13 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_25_121212) do
     t.index ["user_id"], name: "index_items_on_user_id"
   end
 
+  create_table "user_transacts", charset: "utf8", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "item_id", null: false
+    t.index ["item_id"], name: "index_user_transacts_on_item_id"
+  end
+
   create_table "users", charset: "utf8", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -75,4 +82,5 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_25_121212) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "items", "users"
+  add_foreign_key "user_transacts", "items"
 end

--- a/spec/factories/user_transacts.rb
+++ b/spec/factories/user_transacts.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :user_transact do
+    
+  end
+end

--- a/spec/models/user_transact_spec.rb
+++ b/spec/models/user_transact_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe UserTransact, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
＃WHAT
詳細表示機能の実装
＃WHY
商品の詳細の表示を可能とするため

以下動画、画像
*購入機能後SOLD OUT機能の実装については、未実装なので今回は省く*

 ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
 https://gyazo.com/0280943e20a3e0ca0c6b7e6297c625cc
ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
 https://gyazo.com/2744dcf6781dc96e88988ca0b55d7b48
 ログアウト状態で、商品詳細ページへ遷移した動画
https://gyazo.com/fdfa917e4bf35590d167177a147f4810